### PR TITLE
Addition of basic Dependabot configuration

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,12 @@
+# Basic dependabot.yml file
+# REF: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+  # Enable version updates for Actions
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I discovered use of a deprecated version of the Spellcheck action: `0.23.0` in your repository, a version which I was about to delete from Dockerhub.

I recognized the organisation name and could see my previous pull requests on another repository for both spellcheck updates and dependabot configuration.

- https://github.com/NeuroJSON/jdata/pull/8
- https://github.com/NeuroJSON/jdata/pull/9

So here is a dependabot configuration lifted from: NeuroJSON/jdata by merging this you should be good to go.

REF:
- https://github.com/NeuroJSON/jdata/blob/master/.github/dependabot.yml

Do note I will be removing `0.23.0` from DockerHub shortly.